### PR TITLE
Small bug with Selectable Cards

### DIFF
--- a/Assets/Scripts/CardSelectable.cs
+++ b/Assets/Scripts/CardSelectable.cs
@@ -101,6 +101,7 @@ public class CardSelectable : MonoBehaviour
 
     public void Deselect()
     {
+        player.PlayCardButton.interactable = false;
         selected = false;
         s.somethingSelected = false;
         s.Selected = null;


### PR DESCRIPTION
Deselecting a card should also make the PlayCardButton uninteractable; otherwise a nullReferenceException can happen.