### PR TITLE
Changed the code for obstacle checking on the tiled grid, such that the A* path finding works around obstacles, for the enemy

### DIFF
--- a/Assets/Scripts/EnemyAI.cs
+++ b/Assets/Scripts/EnemyAI.cs
@@ -221,7 +221,7 @@ public class EnemyAI : MonoBehaviour
                 neighborNode.F = neighborNode.G + neighborNode.H;
                 Debug.Log("F, G, H:  " + neighborNode.F + ", " + neighborNode.G + ", " + neighborNode.H);
 
-                 if (neighborNode == Obstacle)
+                 if (neighborNode.walkable == false)
                 {
                     neighborNode.G = 100000;
                     neighborNode.H = 100000;


### PR DESCRIPTION
Added this chunk - 
   if (neighborNode.walkable == false)
                {
                    neighborNode.G = 100000;
                    neighborNode.H = 100000;
                    neighborNode.F = 100000;
                }

If there is an obstacle - the walkable property is false on the neighboring node. The walkable property is true by default, and overridden to false during the TileMap Generation when an obstacle is placed on it. If there is an obstacle, the F, G and H values are set to high values such that the enemy does not move to the neighboring tiles which contain obstacles. 