### PR TITLE
Added Event TurnEnded to Turns Class, and progress on the Shop Scene

### DIFF
--- a/Assets/Scenes/Shop.unity
+++ b/Assets/Scenes/Shop.unity
@@ -350,7 +350,20 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 96425154}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 8019044311654091627, guid: a896d06dcb63bb1419524c0f3ddb552a,
+          type: 3}
+        m_TargetAssemblyTypeName: SceneElementController, Assembly-CSharp
+        m_MethodName: LoadTileMovementScene
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &96425154
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1043,6 +1056,8 @@ MonoBehaviour:
   InstantiatedCards: []
   shopSize: 6
   positions: []
+  cardCost: 250
+  destroyCost: 100
 --- !u!1 &717340657
 GameObject:
   m_ObjectHideFlags: 0
@@ -1640,6 +1655,120 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1275550653}
   m_CullTransparentMesh: 1
+--- !u!1 &1336486483
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1336486487}
+  - component: {fileID: 1336486486}
+  - component: {fileID: 1336486485}
+  - component: {fileID: 1336486484}
+  - component: {fileID: 1336486488}
+  m_Layer: 5
+  m_Name: DeckUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1336486484
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336486483}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1336486485
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336486483}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1336486486
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336486483}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1336486487
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336486483}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &1336486488
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336486483}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 16774ae5bb5bcc841838d13eb41258c4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  selected: {fileID: 0}
+  somethingSelected: 0
 --- !u!1 &1380525809
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Deck.cs
+++ b/Assets/Scripts/Deck.cs
@@ -1,12 +1,14 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class Deck : MonoBehaviour
 {
-    public List<Card> Cards = new List<Card>();
+    public List<Card> CurrentDeck = new List<Card>();
+    public List<Card> FullDeck = new List<Card>();
     public ListOfAllCards AllCards;
-    public int initialDeckSize = 5;
+    public int initialDeckSize = 7;
     public Hand PlayerHand;
     public Graveyard Graveyard;
 
@@ -19,6 +21,7 @@ public class Deck : MonoBehaviour
         //GenerateDeckRandomly();
         GenerateKnightDeck();
         //DontDestroyOnLoad(this);
+        SceneManager.sceneLoaded += ResetDeck;
     }
 
     // Update is called once per frame
@@ -29,42 +32,52 @@ public class Deck : MonoBehaviour
 
     public void GenerateDeckRandomly()
     {
-        Cards = new List<Card>();
+        CurrentDeck = new List<Card>();
         for(int i = 0; i < initialDeckSize; i++)
         {
-            Cards.Add(AllCards.DrawRandom());
+            Card added = AllCards.DrawRandom();
+            CurrentDeck.Add(added);
+            FullDeck.Add(added);
         }
     }
 
     public void GenerateKnightDeck()
     {
-        Cards = new List<Card>();
+        CurrentDeck = new List<Card>();
 
         //ArmorUp card
-        Cards.Add(AllCards.AllCards[0]);
+        CurrentDeck.Add(AllCards.DrawByIndex(0));
+        FullDeck.Add(AllCards.DrawByIndex(0));
         //HeavyHand card
-        Cards.Add(AllCards.AllCards[7]);
+        CurrentDeck.Add(AllCards.DrawByIndex(7));
+        FullDeck.Add(AllCards.DrawByIndex(7));
         //DoubleStrike card
-        Cards.Add(AllCards.AllCards[2]);
+        CurrentDeck.Add(AllCards.DrawByIndex(2));
+        FullDeck.Add(AllCards.DrawByIndex(2));
         //Multi-Attack card
-        Cards.Add(AllCards.AllCards[8]);
+        CurrentDeck.Add(AllCards.DrawByIndex(8));
+        FullDeck.Add(AllCards.DrawByIndex(8));
         //CrushingBlow card
-        Cards.Add(AllCards.AllCards[1]);
+        CurrentDeck.Add(AllCards.DrawByIndex(1));
+        FullDeck.Add(AllCards.DrawByIndex(1));
         //Fireball card
-        Cards.Add(AllCards.AllCards[9]);
+        CurrentDeck.Add(AllCards.DrawByIndex(9));
+        FullDeck.Add(AllCards.DrawByIndex(9));
     }
 
     public int AddCard(Card c)
     {
-        Cards.Add(c);
-        return Cards.Count;
+        CurrentDeck.Add(c);
+        FullDeck.Add(c);
+        return CurrentDeck.Count;
     }
 
     public bool RemoveCard(Card c)
     {
-        if (Cards.Contains(c))
+        if (CurrentDeck.Contains(c))
         {
-            Cards.Remove(c);
+            CurrentDeck.Remove(c);
+            FullDeck.Remove(c);
             return true;
         }
         else
@@ -73,19 +86,19 @@ public class Deck : MonoBehaviour
 
     public Card DrawCard()
     {
-        if (Cards.Count > 0)
+        if (CurrentDeck.Count > 0)
         {
-            Card drawn = Cards[0];
-            Cards.Remove(drawn);
+            Card drawn = CurrentDeck[0];
+            CurrentDeck.Remove(drawn);
             return drawn;
         }
         else
         {
             ShuffleDeck();
-            if (Cards.Count <= 0)
+            if (CurrentDeck.Count <= 0)
                 return null;
-            Card drawn = Cards[0];
-            Cards.Remove(drawn);
+            Card drawn = CurrentDeck[0];
+            CurrentDeck.Remove(drawn);
             return drawn;
             
         }
@@ -96,13 +109,18 @@ public class Deck : MonoBehaviour
         if (Graveyard == null)
             Graveyard = FindObjectOfType<Graveyard>();
         Graveyard.ReturnCardsToDeck();
-        for (int i = 0; i < Cards.Count; i++)
+        for (int i = 0; i < CurrentDeck.Count; i++)
         {
-            Card temp = Cards[i];
-            int r = Random.Range(0, Cards.Count);
-            Cards[i] = Cards[r];
-            Cards[r] = temp;
+            Card temp = CurrentDeck[i];
+            int r = Random.Range(0, CurrentDeck.Count);
+            CurrentDeck[i] = CurrentDeck[r];
+            CurrentDeck[r] = temp;
         }
+    }
+
+    public void ResetDeck(Scene s, LoadSceneMode m)
+    {
+        CurrentDeck = FullDeck;
     }
 
 }

--- a/Assets/Scripts/Graveyard.cs
+++ b/Assets/Scripts/Graveyard.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class Graveyard : MonoBehaviour
 {
@@ -11,7 +12,8 @@ public class Graveyard : MonoBehaviour
     void Start()
     {
         Deck = FindObjectOfType<Deck>();
-       //DontDestroyOnLoad(this);
+        //DontDestroyOnLoad(this);
+        SceneManager.sceneLoaded += ResetGraveyard;
     }
 
     // Update is called once per frame
@@ -32,5 +34,10 @@ public class Graveyard : MonoBehaviour
     public void Discard(Card c)
     {
         DiscardedCards.Add(c);
+    }
+
+    public void ResetGraveyard(Scene s, LoadSceneMode m)
+    {
+        DiscardedCards = new List<Card>();
     }
 }

--- a/Assets/Scripts/Hand.cs
+++ b/Assets/Scripts/Hand.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class Hand : MonoBehaviour
 {
@@ -18,6 +19,7 @@ public class Hand : MonoBehaviour
         Deck = FindObjectOfType<Deck>();
         Graveyard = FindObjectOfType<Graveyard>();
         DontDestroyOnLoad(this.transform.parent);
+        SceneManager.sceneLoaded += ResetHand;
     }
 
     // Update is called once per frame
@@ -66,16 +68,20 @@ public class Hand : MonoBehaviour
 
     public void CardPlayed(Card c)
     {
-        for(int i = 0; i < CurrentHand.Count; i++)
-        {
-            if(CurrentHand[i].GetType() == c.GetType())
-            {
-                Graveyard.Discard(CurrentHand[i]);
-                CurrentHand.RemoveAt(i);
-                InstantiatedCards.RemoveAt(i);
-                break;
-            }
-        }
+        //for(int i = 0; i < CurrentHand.Count; i++)
+        //{
+        //    if(CurrentHand[i].GetType() == c.GetType())
+        //    {
+        //        Graveyard.Discard(CurrentHand[i]);
+        //        CurrentHand.RemoveAt(i);
+        //        InstantiatedCards.RemoveAt(i);
+        //        break;
+        //    }
+        //}
+        int i = InstantiatedCards.IndexOf(c);
+        Graveyard.Discard(CurrentHand[i]);
+        CurrentHand.RemoveAt(i);
+        InstantiatedCards.RemoveAt(i);
         UpdateCardPositions();
     }
 
@@ -89,5 +95,15 @@ public class Hand : MonoBehaviour
             if(CS.originalP != null)
                 CS.originalP = new Vector3(2 + i * 2f, 0, 0);
         }
+    }
+
+    public void ResetHand(Scene s, LoadSceneMode m)
+    {
+        CurrentHand = new List<Card>();
+        foreach (Card c in InstantiatedCards)
+        {
+            Destroy(c.gameObject);
+        }
+        InstantiatedCards = new List<Card>();
     }
 }

--- a/Assets/Scripts/LerpTowardsTargets.cs
+++ b/Assets/Scripts/LerpTowardsTargets.cs
@@ -43,7 +43,7 @@ public class LerpTowardsTargets : MonoBehaviour
         StartCoroutine(WaitForParticleDespawn(particles.main.startLifetime.constant));
         particles.Stop();
         spawnedOnReachParticles.Play();
-        Debug.Log(spawnedOnReachParticles.main.startLifetime.constant);
+        //Debug.Log(spawnedOnReachParticles.main.startLifetime.constant);
         Destroy(spawned, spawnedOnReachParticles.main.startLifetime.constant);
         Destroy(this.gameObject, spawnedOnReachParticles.main.startLifetime.constant);
     }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -19,6 +19,8 @@ public class Player : MonoBehaviour
     int damage = 20;
     //hand size
     int handSize = 0;
+    //Player's gold
+    public int gold = 0;
     //Reference to the object with the Turns class, which controls when turns are ready.
     [SerializeField]
     public Turns t;
@@ -114,7 +116,7 @@ public class Player : MonoBehaviour
 
         Hand = FindObjectOfType<Hand>();
         CS = GetComponent<CardSelection>();
-        StartCoroutine(StartTurn());
+        //StartCoroutine(StartTurn());
     }
 
     // Update is called once per frame

--- a/Assets/Scripts/SceneElementController.cs
+++ b/Assets/Scripts/SceneElementController.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -37,6 +38,7 @@ public class SceneElementController : MonoBehaviour
             player.GetComponent<PlayerClickToMove>().enabled = false;
             player.GetComponent<Movement>().enabled = false;
             player.t = FindObjectOfType<Turns>();
+            player.t.TurnEnded += DebugTurnEnded;
             Debug.Log("Combat scene loaded");
         }
         else if (scene.name.Equals("TileMovement"))
@@ -51,5 +53,31 @@ public class SceneElementController : MonoBehaviour
             PCTM.EndTurnButton.interactable = true;
             Debug.Log("Tile scene loaded");
         }
+    }
+
+    public void LoadTileMovementScene()
+    {
+        SceneManager.LoadScene("TileMovement");
+    }
+    public void LoadCombatScene()
+    {
+        SceneManager.LoadScene("Combat");
+    }
+
+    public void LoadShopScene()
+    {
+        SceneManager.LoadScene("Shop");
+    }
+
+    public void LoadTreasureScene()
+    {
+        SceneManager.LoadScene("Treasure");
+    }
+
+    //Test for EventHandlers;  Receives the sender and its eventArguments as parameters (Can be avoided/changed/added to following this guide:)
+    // https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/events/how-to-publish-events-that-conform-to-net-framework-guidelines
+    public void DebugTurnEnded(object sender, EventArgs e)
+    {
+        Debug.Log("TurnEnded triggered in SEC");
     }
 }

--- a/Assets/Scripts/Shop.cs
+++ b/Assets/Scripts/Shop.cs
@@ -10,6 +10,8 @@ public class Shop : MonoBehaviour
     public List<Card> InstantiatedCards;
     public int shopSize = 6;
     public Vector3[] positions;
+    public int cardCost = 250;
+    public int destroyCost = 100;
     // Start is called before the first frame update
     void Start()
     {
@@ -37,7 +39,6 @@ public class Shop : MonoBehaviour
         for(int i = 0; i < shopSize; i++)
         {
             CardsToBuy.Add(ListOfAllCards.DrawRandom());
-            Debug.Log("Card Generated: " + CardsToBuy[i].name);
             Card added = Instantiate(CardsToBuy[i]);
             InstantiatedCards.Add(added);
             added.transform.position = positions[i];
@@ -49,7 +50,7 @@ public class Shop : MonoBehaviour
 
     public void BuyCard(int i)
     {
-        if(i >= 0 && i < CardsToBuy.Count)
+        if(i >= 0 && i < CardsToBuy.Count && FindObjectOfType<Player>().gold >= cardCost)
         {
             Deck.AddCard(CardsToBuy[i]);
             Card ToDestroy = InstantiatedCards[i];
@@ -59,13 +60,17 @@ public class Shop : MonoBehaviour
 
     public void RemoveCard(Card c)
     {
-        for (int i = 0; i < Deck.Cards.Count; i++)
+        //for (int i = 0; i < Deck.CurrentDeck.Count; i++)
+        //{
+        //    if (c.GetType() == Deck.CurrentDeck[i].GetType())
+        //    {
+        //        Deck.CurrentDeck.RemoveAt(i);
+        //        break;
+        //    }
+        //}
+        if(FindObjectOfType<Player>().gold >= destroyCost)
         {
-            if (c.GetType() == Deck.Cards[i].GetType())
-            {
-                Deck.Cards.RemoveAt(i);
-                break;
-            }
+            Deck.RemoveCard(c);
         }
     }
 }

--- a/Assets/Scripts/Turns.cs
+++ b/Assets/Scripts/Turns.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System;
 using UnityEngine;
 
 public class Turns : MonoBehaviour
@@ -17,6 +18,9 @@ public class Turns : MonoBehaviour
     //For changing the camera location when one side loses.
     Camera cam;
 
+    //EventHandler to notify when the Player and Enemy's Turns have both ended
+    public event EventHandler TurnEnded;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -30,6 +34,7 @@ public class Turns : MonoBehaviour
         {
             enemies.Add(e);
         }
+        StartCoroutine(p.StartTurn());
 
         //Loop();
     }
@@ -71,6 +76,16 @@ public class Turns : MonoBehaviour
                 //e.transform.position.Set(e.transform.position.x - 1f, e.transform.position.y, e.transform.position.z);
             }
         }
+
+        //Raise TurnEnded Event
+        //If at least 1 subscriber
+        if(TurnEnded != null)
+        {
+            //EventArguments by default need a Sender (this) and an EventArgs object
+            TurnEnded(this, new EventArgs());
+        }
+
+
         //If there are enemies still alive and the player isn't dead, the Player can take their turn.
         if (count > 0 && !p.dead)
         {
@@ -121,3 +136,5 @@ public class Turns : MonoBehaviour
     }
 
 }
+
+


### PR DESCRIPTION
There is now a listener for when both the Enemy's and Player's turns are over - this will be useful for things like Status Effects.  I made some changes to the Shop class, as well as some changes to the Deck, Hand, and Graveyard classes - They now reset when a new scene loads.